### PR TITLE
Fix strlen() out-of-bounds read when buffer is full

### DIFF
--- a/main.c
+++ b/main.c
@@ -86,12 +86,15 @@ static ssize_t dev_write(struct file *filep,
                          size_t len,
                          loff_t *offset)
 {
-    size_of_message = 0;
     memset(message, 0, sizeof(char) * BUFF_SIZE);
 
-    copy_from_user(message, buffer, BUFF_SIZE);
-    size_of_message = strlen(message);
-    printk(KERN_INFO "CALC: Received %d -> %s\n", size_of_message, message);
+    if (len >= BUFF_SIZE) {
+        printk(KERN_ALERT "Expression too long");
+        return 0;
+    }
+
+    copy_from_user(message, buffer, len);
+    printk(KERN_INFO "CALC: Received %ld -> %s\n", len, message);
 
     calc();
     return len;


### PR DESCRIPTION
https://github.com/sysprog21/kcalc/blob/62c15c2f49013564748d3f1fd59b548585dd02c7/main.c#L92-L94
The code snippet in `dev_write` function can be abused by attacker to leak kernel pointer or data, or cause fortify panic in kernel.

PoC:
```c
#include <stdio.h>
#include <string.h>
#include <fcntl.h>
#include <unistd.h>

char badstr[256];
char output[256];

int main() {
  int fd = open("/dev/calc", 2, 0);
  if (fd<0) {
    puts("open failed"); return 0; 
  }
  memset(badstr, 0x41, 256);

  write(fd, badstr, 256);
  read(fd, output, 256);
  puts(output);
  close(fd);
  return 0;
}
```
![image](https://user-images.githubusercontent.com/18047532/74230490-731eef00-4cff-11ea-82ec-3756d4cef737.png)
